### PR TITLE
syntax fixes

### DIFF
--- a/docs/section_1.md
+++ b/docs/section_1.md
@@ -121,7 +121,7 @@ Now we will install a few tools that we'll use.  Esptool is used to flash MicroP
 
 ```shell
 pip install esptool
-esptool.py --version
+esptool.py version
 ```
 
 Note that once installed, esptool must be called with the .py extension:  `esptool.py`.  Run it with no arguments to get help on its various commands.

--- a/docs/section_3.md
+++ b/docs/section_3.md
@@ -30,7 +30,7 @@ I'll briefly show the access point configuration, but we'll be mostly concerned 
 
 ```python
 ap = network.WLAN(network.AP_IF)
-print(ap.isactive())
+print(ap.active())
 ap.active(True)
 ap.config(essid='fireant', password='meatmeat')
 
@@ -76,7 +76,7 @@ WIFI_PASSWORD = '<replace with your network password'
 
 wifi = network.WLAN(network.STA_IF)
 wifi.active(True)
-wifi.connect(WIFI_SSID, WIFI_PASSSWORD)
+wifi.connect(WIFI_SSID, WIFI_PASSWORD)
 
 while not wifi.isconnected():
     pass


### PR DESCRIPTION
section 1: esptool.py: `--version` wasn't a valid option on the mac, but `version` was. 
section 3: switch `WLAN.isactive()` (undefined) to `WLAN.active()`
section 3: remove extra 'S' in `WIFI_PASSWORD`